### PR TITLE
CEDESK-1725 Detailed error msg for failing threads

### DIFF
--- a/cap-ext-parallelize.gemspec
+++ b/cap-ext-parallelize.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{cap-ext-parallelize}
-  s.version = "0.1.3"
+  s.version = "0.1.4"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Mathias Meyer"]

--- a/lib/capistrano/configuration/extensions/actions/invocation.rb
+++ b/lib/capistrano/configuration/extensions/actions/invocation.rb
@@ -37,7 +37,7 @@ module Capistrano
               if threads.any? {|t| t[:rolled_back] || t[:exception_raised]}
                 error_threads = threads.select {|t| t[:rolled_back] || t[:exception_raised]}
                 rollback_all_threads(error_threads.flatten)
-                logger.debug "ERROR : Subthread failed in parallel running with above exception(s)"
+                logger.debug "ERROR : Subthread #{error_threads} failed in parallel running with #{t[:exception_raised]} exception(s)"
                 abort
               end
               batch += 1


### PR DESCRIPTION
## JIRA

* [CEDESK-1725](https://coupadev.atlassian.net/browse/CEDESK-1725)

## Summary of issue

Difficult to understand failure root cause with error * ERROR : Subthread failed in parallel running with above exception(s)

## Summary of change

- Updated the error message with failing thread details and the exception for failure
- Updated the gem version for cap-ext-parallelize

## RFC
[RFC-51341](https://coupadev.atlassian.net/browse/RFC-51341)
